### PR TITLE
deps: Moved Mocha & Chai to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   },
   "homepage": "https://github.com/tinyrick/tinyrick#readme",
   "dependencies": {
+    "lodash": "^3.10.1"
+  },
+  "devDependencies": {
     "chai": "^3.3.0",
-    "lodash": "^3.10.1",
     "mocha": "^2.3.3"
   }
 }


### PR DESCRIPTION
Chai & Mocha are used for testing, this reduces package size when installed. 
